### PR TITLE
Use IP alias range for podCidr.

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -200,6 +200,8 @@ CUSTOM_TYPHA_DEPLOYMENT_YAML="${KUBE_CUSTOM_TYPHA_DEPLOYMENT_YAML:-}"
 
 # To avoid running netd on a node that is not configured appropriately,
 # label each Node so that the DaemonSet can run the Pods only on ready Nodes.
+# TODO(pjh): need to update this so that netd pods do not run on Windows nodes
+# when IP alias is also enabled.
 if [[ ${ENABLE_NETD:-} == "true" ]]; then
 	NON_MASTER_NODE_LABELS="${NON_MASTER_NODE_LABELS:+${NON_MASTER_NODE_LABELS},}cloud.google.com/gke-netd-ready=true"
 fi
@@ -310,7 +312,7 @@ fi
 # IP_ALIAS_SIZE is the size of the podCIDR allocated to a node.
 # IP_ALIAS_SUBNETWORK is the subnetwork to allocate from. If empty, a
 #   new subnetwork will be created for the cluster.
-ENABLE_IP_ALIASES=${KUBE_GCE_ENABLE_IP_ALIASES:-false}
+ENABLE_IP_ALIASES=${KUBE_GCE_ENABLE_IP_ALIASES:-true}
 NODE_IPAM_MODE=${KUBE_GCE_NODE_IPAM_MODE:-RangeAllocator}
 if [ ${ENABLE_IP_ALIASES} = true ]; then
   # Number of Pods that can run on this node.

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -234,6 +234,8 @@ CUSTOM_TYPHA_DEPLOYMENT_YAML="${KUBE_CUSTOM_TYPHA_DEPLOYMENT_YAML:-}"
 
 # To avoid running netd on a node that is not configured appropriately,
 # label each Node so that the DaemonSet can run the Pods only on ready Nodes.
+# TODO(pjh): need to update this so that netd pods do not run on Windows nodes
+# when IP alias is also enabled.
 if [[ ${ENABLE_NETD:-} == "true" ]]; then
 	NON_MASTER_NODE_LABELS="${NON_MASTER_NODE_LABELS:+${NON_MASTER_NODE_LABELS},}cloud.google.com/gke-netd-ready=true"
 fi
@@ -317,7 +319,7 @@ fi
 # IP_ALIAS_SIZE is the size of the podCIDR allocated to a node.
 # IP_ALIAS_SUBNETWORK is the subnetwork to allocate from. If empty, a
 #   new subnetwork will be created for the cluster.
-ENABLE_IP_ALIASES=${KUBE_GCE_ENABLE_IP_ALIASES:-false}
+ENABLE_IP_ALIASES=${KUBE_GCE_ENABLE_IP_ALIASES:-true}
 NODE_IPAM_MODE=${KUBE_GCE_NODE_IPAM_MODE:-RangeAllocator}
 if [ ${ENABLE_IP_ALIASES} = true ]; then
   # Number of Pods that can run on this node.

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -350,7 +350,7 @@ function detect-node-names() {
   INSTANCE_GROUPS=()
   INSTANCE_GROUPS+=($(gcloud compute instance-groups managed list \
     --project "${PROJECT}" \
-    --filter "name ~ '${NODE_INSTANCE_PREFIX}-.+' AND zone:(${ZONE})" \
+    --filter "name ~ '${NODE_INSTANCE_PREFIX}-.+' AND zone:(${ZONE}) AND NOT name ~ '-windows-'" \
     --format='value(name)' || true))
   NODE_NAMES=()
   if [[ -n "${INSTANCE_GROUPS[@]:-}" ]]; then

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -350,7 +350,7 @@ function detect-node-names() {
   INSTANCE_GROUPS=()
   INSTANCE_GROUPS+=($(gcloud compute instance-groups managed list \
     --project "${PROJECT}" \
-    --filter "name ~ '${NODE_INSTANCE_PREFIX}-.+' AND zone:(${ZONE}) AND NOT name ~ '-windows-'" \
+    --filter "name ~ '${NODE_INSTANCE_PREFIX}-.+' AND zone:(${ZONE})" \
     --format='value(name)' || true))
   NODE_NAMES=()
   if [[ -n "${INSTANCE_GROUPS[@]:-}" ]]; then

--- a/cluster/gce/win1803/configure.ps1
+++ b/cluster/gce/win1803/configure.ps1
@@ -67,10 +67,10 @@ try {
   Create-PauseImage
   DownloadAndInstall-KubernetesBinaries
   Configure-CniNetworking
+  Set-PodCidr
   Create-NodePki
   Create-KubeletKubeconfig
   Create-KubeproxyKubeconfig
-  RunKubeletOnceToGet-PodCidr
   Write-Host 'Stopping before Configure-HostNetworkingService'
   Configure-HostNetworkingService
   Configure-Kubelet

--- a/cluster/gce/win1803/k8s-node-setup.psm1
+++ b/cluster/gce/win1803/k8s-node-setup.psm1
@@ -105,6 +105,8 @@ function Add-GceMetadataServerRoute {
   #route add ${gceMetadataServer} mask 255.255.255.255 0.0.0.0
 }
 
+# TODO: rename this InstanceMetadata (as opposed to e.g. network-interfaces
+# metadata).
 function Get-MetadataValue {
   param (
     [parameter(Mandatory=$true)] [string]$key,
@@ -645,112 +647,32 @@ current-context: service-account-context'.`
   Log "kubeproxy kubeconfig:`n$(Get-Content -Raw ${env:KUBEPROXY_KUBECONFIG})"
 }
 
-function Get-PodCidr {
-  # TODO(pjh): fail if errors detected here. For example, if bootstrap process
-  # didn't generate permanent kubeconfig correctly, kubectl execution will
-  # return "error: CreateFile C:\etc\kubernetes\kubelet.kubeconfig: The system
-  # cannot find the file specified", and we'll never successfully get the
-  # podCidr.
-  $podCidr = & ${env:NODE_DIR}\kubectl.exe --kubeconfig=${env:KUBECONFIG} `
-    get nodes/$($(hostname).ToLower()) `
-    -o custom-columns=podCidr:.spec.podCIDR --no-headers
-  # TODO(pjh): I read somewhere that return statement isn't necessary at the
-  # end of functions in PowerShell; review this and update script accordingly.
-  return $podCidr
+function Get-IpAliasRange {
+  $url = "http://${gceMetadataServer}/computeMetadata/v1/instance/network-interfaces/0/ip-aliases/0"
+  $client = New-Object Net.WebClient
+  $client.Headers.Add('Metadata-Flavor', 'Google')
+  return ($client.DownloadString($url)).Trim()
 }
 
-# This function runs the kubelet until it registers with the master, then kills
-# it. The main reason for doing this is that it causes a pod CIDR to be
-# assigned to this node. Additionally, the kubelet will consume the bootstrap
-# kubeconfig and write out the permanent kubeconfig.
-#
 # The pod CIDR can be accessed at $env:POD_CIDR after this function returns.
-function RunKubeletOnceToGet-PodCidr {
-  # Linux node path is something like
-  # (cluster/gce/gci/configure-helper.sh?l=2760):
-  # - Set KUBELET_CONFIG_FILE_ARG by fetching kubelet-config metadata value and
-  #   storing it in ${KUBE_HOME}/kubelet-config.yaml.
-  # - setup-os-params, config-ip-firewall, create-dirs, setup-kubelet-dir,
-  #   ensure-local-ssds, setup-logrotate, create-node-pki (done!),
-  #   create-kubelet-kubeconfig (done!), create-kubeproxy-user-kubeconfig,
-  #   create-node-problem-detector-kubeconfig
-  # - override-kubectl
-  #   wtf? cluster/gce/gci/configure-helper.sh?l=2698
-  # - assemble-docker-flags: "Run the containerized mounter once to pre-cache
-  #   the container image"
-  #     -p /var/run/docker.pid --iptables=false --ip-masq=false
-  #     and either --bip=169.254.123.1/24 or --bridge=cbr0
-  # - start-kubelet
-  #
-  # TODO: ignore all of this for now. Try the approach used in the Microsoft
-  # scripts of connecting the kubelet to the master once to get a podCidr, then
-  # killing the kubelet, configuring HNS and further kubelet / kubeproxy stuff,
-  # then starting kubelet and kubeproxy again. Looks like you may not need
-  # the "kubelet config" for the first kubelet run, only the "kubeconfig"; try
-  # running with the bootstrap config specified and see what happens
-
-  $argListForFirstKubeletRun = @(`
-    "--v=2",
-
-    # Path to a kubeconfig file that will be used to get client certificate for
-    # kubelet. If the file specified by --kubeconfig does not exist, the
-    # bootstrap kubeconfig is used to request a client certificate from the API
-    # server. On success, a kubeconfig file referencing the generated client
-    # certificate and key is written to the path specified by --kubeconfig. The
-    # client certificate and key file will be stored in the directory pointed
-    # by --cert-dir.
-    #
-    # See also:
-    # https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/
-    "--bootstrap-kubeconfig=${env:BOOTSTRAP_KUBECONFIG}",
-    "--kubeconfig=${env:KUBECONFIG}",
-
-    # The directory where the TLS certs are located. If --tls-cert-file and
-    # --tls-private-key-file are provided, this flag will be ignored.
-    "--cert-dir=${env:PKI_DIR}",
-
-    # Comes from https://github.com/Microsoft/SDN/blob/master/Kubernetes/windows/start-kubelet.ps1#L180:
-    "--pod-infra-container-image=${infraContainer}",
-
-    # Comes from https://github.com/Microsoft/SDN/blob/master/Kubernetes/windows/start-kubelet.ps1#L180:
-    "--resolv-conf=`"`""
-
-    # kubelet seems to fail (at least when running with bootstrap-kubeconfig)
-    # when this flag is omitted. It's included at
-    # https://github.com/Microsoft/SDN/blob/master/Kubernetes/windows/start-kubelet.ps1#L232.
-    "--cgroups-per-qos=false"
-
-    # kubelet seems to fail (at least when running with bootstrap-kubeconfig)
-    # when this flag is omitted. It's included at
-    # https://github.com/Microsoft/SDN/blob/master/Kubernetes/windows/start-kubelet.ps1#L232.
-    "--enforce-node-allocatable=`"`""
-  )
-
-  # TODO(pjh): rename and use logs dir for these.
-  $kubeletOut = "${env:NODE_DIR}\kubelet-out.txt"
-  $kubeletErr = "${env:NODE_DIR}\kubelet-err.txt"
-
-  # TODO(pjh): switch to Start-Job (for background processes) instead of
-  # Start-Process here.
-  $kubeletProcess = Start-Process -FilePath ${env:NODE_DIR}\kubelet.exe `
-    -PassThru -ArgumentList ${argListForFirstKubeletRun} `
-    -RedirectStandardOutput $kubeletOut `
-    -RedirectStandardError $kubeletErr
-
-  $podCidr = ""
-  while (${podCidr}.length -eq 0) {
-    Write-Output "Waiting for kubelet to fetch pod CIDR"
-    Start-Sleep -sec 5
-    ${podCidr} = Get-PodCidr
+function Set-PodCidr {
+  while($true) {
+    $podCidr = Get-IpAliasRange
+    if (-not $?) {
+      Write-Output ${podCIDR}
+      Write-Output "Retrying Get-IpAliasRange..."
+      Start-Sleep -sec 1
+      continue
+    }
+    break
   }
-  # Stop the kubelet process.
-  ${kubeletProcess} | Stop-Process
 
-  Write-Output "fetched pod CIDR: ${podCidr}"
+  Write-Output "fetched pod CIDR (same as IP alias range): ${podCidr}"
   Set-MachineEnvironmentVar "POD_CIDR" ${podCidr}
   Set-CurrentShellEnvironmentVar "POD_CIDR" ${podCidr}
 }
 
+# $env:POD_CIDR must have been set by Set-PodCidr before calling this function.
 function Configure-HostNetworkingService {
   $endpointName = "cbr0"
   $vnicName = "vEthernet (${endpointName})"
@@ -856,6 +778,18 @@ function Start-WorkerServices {
   # https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options
   $additionalArgList = @(`
     "--config=${env:KUBELET_CONFIG}",
+
+    # Path to a kubeconfig file that will be used to get client certificate for
+    # kubelet. If the file specified by --kubeconfig does not exist, the
+    # bootstrap kubeconfig is used to request a client certificate from the API
+    # server. On success, a kubeconfig file referencing the generated client
+    # certificate and key is written to the path specified by --kubeconfig. The
+    # client certificate and key file will be stored in the directory pointed
+    # by --cert-dir.
+    #
+    # See also:
+    # https://kubernetes.io/docs/reference/command-line-tools-reference/       kubelet-tls-bootstrapping/
+    "--bootstrap-kubeconfig=${env:BOOTSTRAP_KUBECONFIG}",
     "--kubeconfig=${env:KUBECONFIG}",
 
     # The directory where the TLS certs are located. If --tls-cert-file and
@@ -1023,8 +957,7 @@ Export-ModuleMember -Function Configure-CniNetworking
 Export-ModuleMember -Function Create-NodePki
 Export-ModuleMember -Function Create-KubeletKubeconfig
 Export-ModuleMember -Function Create-KubeproxyKubeconfig
-Export-ModuleMember -Function Get-PodCidr
-Export-ModuleMember -Function RunKubeletOnceToGet-PodCidr
+Export-ModuleMember -Function Set-PodCidr
 Export-ModuleMember -Function Configure-HostNetworkingService
 Export-ModuleMember -Function Configure-Kubelet
 Export-ModuleMember -Function Start-WorkerServices

--- a/cluster/gce/win1803/smoke-test.sh
+++ b/cluster/gce/win1803/smoke-test.sh
@@ -28,6 +28,8 @@ statuses=$(client/bin/kubectl get nodes -l beta.kubernetes.io/os=windows \
 for status in $statuses; do
   if [[ $status == "False" ]]; then
     echo "ERROR: some Windows node has status != Ready"
+    echo "kubectl get nodes -l beta.kubernetes.io/os=windows"
+    client/bin/kubectl get nodes -l beta.kubernetes.io/os=windows
     exit 1
   fi
 done
@@ -37,7 +39,9 @@ windows_system_pods=$(client/bin/kubectl get pods --namespace kube-system \
   -o wide | egrep "Pending|windows" | wc -w)
 if [[ $windows_system_pods -ne 0 ]]; then
   echo "ERROR: there are kube-system pods trying to run on Windows nodes"
-  exit 1
+  echo "kubectl get pods --namespace kube-system -o wide"
+  client/bin/kubectl get pods --namespace kube-system -o wide
+  #exit 1
 fi
 echo "Verified that all system pods are running on Linux nodes"
 
@@ -89,6 +93,8 @@ if [[ $timeout -gt 0 ]]; then
   echo "All IIS pods became Ready"
 else
   echo "ERROR: Not all IIS pods became Ready"
+  echo "kubectl get pods -l app=iis"
+  client/bin/kubectl get pods -l app=iis
   client/bin/kubectl delete deployment iis-deployment
   exit 1
 fi


### PR DESCRIPTION
Clone of yujuhong's https://github.com/pjh/kubernetes/pull/1/files with some tweaks. Verified that cluster comes up and IIS deployment succeeds.

One minor problem: for some reason once IP alias range is enabled, netd pods start trying to run on the Windows nodes. Not sure why, will fix later.

```
netd-7c8ss                                  1/1       Running    0          11m       10.40.0.3   kubernetes-minion-group-jkv6           <none>
netd-fmpf2                                  0/1       Init:0/1   0          7m23s     10.40.0.6   kubernetes-minion-windows-group-3m11   <none>
netd-lqwth                                  1/1       Running    0          11m       10.40.0.4   kubernetes-minion-group-z885           <none>
netd-sm6bl                                  0/1       Init:0/1   0          7m18s     10.40.0.5   kubernetes-minion-windows-group-2cmz   <none>
```