### PR TITLE
Switch "management" interface to Ethernet instead of vEthernet (nat).

### DIFF
--- a/cluster/gce/win1803/k8s-node-setup.psm1
+++ b/cluster/gce/win1803/k8s-node-setup.psm1
@@ -30,8 +30,9 @@ $gceMetadataServer = "169.254.169.254"
 # The name of the primary "physical" network adapter for the Windows VM.
 $primaryNetAdapterName = "Ethernet"
 # TODO: describe what the "management" interface is for.
+# Earlier versions of this script used "vEthernet (nat*" for the management interface, but
+# node-to-pod traffic did not work until switching to "Ethernet" instead.
 $mgmtAdapterName = "Ethernet"
-#$mgmtAdapterName = "vEthernet (nat*"
 
 function Log {
   param (

--- a/cluster/gce/win1803/k8s-node-setup.psm1
+++ b/cluster/gce/win1803/k8s-node-setup.psm1
@@ -29,6 +29,9 @@ Export-ModuleMember -Variable infraContainer
 $gceMetadataServer = "169.254.169.254"
 # The name of the primary "physical" network adapter for the Windows VM.
 $primaryNetAdapterName = "Ethernet"
+# TODO: describe what the "management" interface is for.
+$mgmtAdapterName = "Ethernet"
+#$mgmtAdapterName = "vEthernet (nat*"
 
 function Log {
   param (
@@ -326,8 +329,7 @@ ConvertTo-MaskLength
 #
 # TODO(pjh): update this to return both $addr as well as $mgmtSubnet.
 function Get-MgmtSubnet {
-  # TODO(pjh): make "vEthernet (nat*" a constant somewhere.
-  $netAdapter = Get-NetAdapter | Where-Object Name -Like "vEthernet (nat*"
+  $netAdapter = Get-NetAdapter | Where-Object Name -Like ${mgmtAdapterName}
   if (!${netAdapter}) {
     throw "Failed to find a suitable network adapter, check your network settings."
   }
@@ -355,7 +357,7 @@ function Configure-CniNetworking {
   mv ${env:CNI_DIR}\bin\*.exe ${env:CNI_DIR}\
   rmdir ${env:CNI_DIR}\bin
 
-  $vethIp = (Get-NetAdapter | Where-Object Name -Like "vEthernet (nat*" |`
+  $vethIp = (Get-NetAdapter | Where-Object Name -Like ${mgmtAdapterName} |`
     Get-NetIPAddress -AddressFamily IPv4).IPAddress
   $mgmtSubnet = Get-MgmtSubnet
   Log "using mgmt IP ${vethIp} and mgmt subnet ${mgmtSubnet} for CNI config"
@@ -629,6 +631,8 @@ function Configure-HostNetworkingService {
     -Name ${endpointName} -IPAddress ${podEndpointGateway} `
     -Gateway "0.0.0.0" -Verbose
   Attach-HnsHostEndpoint -EndpointID ${hnsEndpoint}.Id -CompartmentID 1 -Verbose
+  netsh interface ipv4 set interface "vEthernet (nat)" forwarding=enabled
+  netsh interface ipv4 set interface "vEthernet (Ethernet)" forwarding=enabled
   netsh interface ipv4 set interface "${vnicName}" forwarding=enabled
   Get-HNSPolicyList | Remove-HnsPolicyList
 

--- a/cluster/gce/win1803/k8s-node-setup.psm1
+++ b/cluster/gce/win1803/k8s-node-setup.psm1
@@ -632,8 +632,6 @@ function Configure-HostNetworkingService {
     -Name ${endpointName} -IPAddress ${podEndpointGateway} `
     -Gateway "0.0.0.0" -Verbose
   Attach-HnsHostEndpoint -EndpointID ${hnsEndpoint}.Id -CompartmentID 1 -Verbose
-  netsh interface ipv4 set interface "vEthernet (nat)" forwarding=enabled
-  netsh interface ipv4 set interface "vEthernet (Ethernet)" forwarding=enabled
   netsh interface ipv4 set interface "${vnicName}" forwarding=enabled
   Get-HNSPolicyList | Remove-HnsPolicyList
 


### PR DESCRIPTION
With this PR, curl-ing from the kubernetes-master **node** to a e2eteam/nettest:1.0 **pod** running on a Windows node works.

Also verified:
- curl from Linux node to Linux pod.
- curl from Linux pod to Windows pod.
- curl from Linud pod to Linux pod.
- curl from Windows node to Windows pod
- curl from Windows node to Linux pod
- curl from Windows pod to Windows pod.
- curl from Windows pod to Linux pod.

Woohoo!
[test-connectivity.txt](https://github.com/pjh/kubernetes/files/2587797/test-connectivity.txt)

