### PR TITLE
Use the proper management interface and add relevant comments.

### DIFF
--- a/cluster/gce/win1803/configure.ps1
+++ b/cluster/gce/win1803/configure.ps1
@@ -62,16 +62,18 @@ try {
   Set-EnvironmentVars
   Set-PrerequisiteOptions
   Create-Directories
+  Download-HelperScripts
 
   $kubeEnv = Download-KubeEnv
   Create-PauseImage
   DownloadAndInstall-KubernetesBinaries
-  Set-PodCidr
-  Configure-CniNetworking
   Create-NodePki
   Create-KubeletKubeconfig
   Create-KubeproxyKubeconfig
+  Set-PodCidr
+  Add-InitialHnsNetwork
   Configure-HostNetworkingService
+  Configure-CniNetworking
   Configure-Kubelet
 
   Start-WorkerServices


### PR DESCRIPTION
Follow-up to #26. This change rearranges the HNS network creation and ensures that the "vEthernet (Ethernet)" interface is used for the "management" interface.

With this PR, connectivity works (still) between Windows pods and Linux nodes and pods. Unfortunately contacting the Internet (`ping 8.8.8.8`, `Invoke-WebRequest -v -TimeoutSec 10 https://chocolatey.org -UseBasicParsing`, or `Test-NetConnection -InformationLevel Detailed`) still does not work.

Did not test: connecting to services from the Windows nodes / pods. There's a chance this will help with that.