### PR TITLE
Update Windows CNI binaries with latest prebuilt win-bridge.

### DIFF
--- a/cluster/gce/win1803/k8s-node-setup.psm1
+++ b/cluster/gce/win1803/k8s-node-setup.psm1
@@ -617,9 +617,11 @@ function Configure-CniNetworking {
     https://github.com/${githubRepo}/kubernetes/raw/${githubBranch}/cluster/gce/windows-cni-plugins.zip `
     -OutFile ${env:CNI_DIR}\windows-cni-plugins.zip
   Expand-Archive ${env:CNI_DIR}\windows-cni-plugins.zip ${env:CNI_DIR}
-  # TODO(pjh): test that the two CNI plugins that we need, win-bridge.exe and
-  # host-local.exe (for IPAM), are present in CNI_DIR.
   mv ${env:CNI_DIR}\bin\*.exe ${env:CNI_DIR}\
+  if (-not ((Test-Path ${env:CNI_DIR}\win-bridge.exe) -and `
+            (Test-Path ${env:CNI_DIR}\host-local.exe))) {
+    Log "win-bridge.exe and host-local.exe not found in ${env:CNI_DIR}" $true
+  }
   rmdir ${env:CNI_DIR}\bin
 
   $vethIp = (Get-NetAdapter | Where-Object Name -Like ${mgmtAdapterName} |`


### PR DESCRIPTION
In November Microsoft released some new prebuilt CNI binaries ([slack thread here](https://kubernetes.slack.com/archives/C0SJ4AFB7/p1542764160229400?thread_ts=1542672657.218600&cid=C0SJ4AFB7)). The code is available somewhere but it hasn't made it to the containernetworking repo yet. This PR updates our clusters to use the prebuilt binaries.

These are the hybrid steps I followed to build the new zip:

Clone github.com/containernetworking/plugins, then run:

$ rm bin/* windows-cni-plugins.zip
$ ./build_windows.sh
$ wget https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/cni/flannel.exe -O bin/flannel.exe
$ wget https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/cni/host-local.exe -O bin/host-local.exe
$ wget https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/cni/win-bridge.exe -O bin/win-bridge.exe
$ zip windows-cni-plugins.zip bin/*.exe

Tested by running:

$ PROJECT=${CLOUDSDK_CORE_PROJECT} KUBERNETES_SKIP_CONFIRM=y \
    GITHUB_BRANCH=win-bridge-plusplus ./cluster/kube-up.sh
$ cluster/gce/win1803/smoke-test.sh