### PR TITLE
Enable serial port logging on Windows nodes

### DIFF
--- a/cluster/gce/win1803/node-helper.sh
+++ b/cluster/gce/win1803/node-helper.sh
@@ -32,6 +32,9 @@ function get-windows-node-instance-metadata-from-file {
   metadata+="install-logging-agent-psm1=${KUBE_ROOT}/cluster/gce/${WINDOWS_NODE_OS_DISTRIBUTION}/install-logging-agent.psm1,"
   metadata+="prepull-images-psm1=${KUBE_ROOT}/cluster/gce/${WINDOWS_NODE_OS_DISTRIBUTION}/prepull-images.psm1,"
   metadata+="k8s-node-setup-psm1=${KUBE_ROOT}/cluster/gce/${WINDOWS_NODE_OS_DISTRIBUTION}/k8s-node-setup.psm1,"
+  # This enables logging the serial port output.
+  # https://cloud.google.com/compute/docs/instances/viewing-serial-port-output
+  metadata+="serial-port-logging-enable=true,"
   metadata+="${NODE_EXTRA_METADATA}"
   echo "${metadata}"
 }


### PR DESCRIPTION
Serial port logs will be sent to stackdriver with the instance metadata
"serial-port-logging-enable" set to true.
