### PR TITLE
WIP: enable log dumping for Windows test nodes

### DIFF
--- a/cluster/centos/util.sh
+++ b/cluster/centos/util.sh
@@ -47,15 +47,6 @@ function detect-masters() {
   echo "KUBE_MASTER_IP_ADDRESSES: [${KUBE_MASTER_IP_ADDRESSES[*]}]" 1>&2
 }
 
-# Get node IP addresses and store in KUBE_NODE_IP_ADDRESSES[]
-function detect-nodes() {
-  KUBE_NODE_IP_ADDRESSES=()
-  for node in ${NODES}; do
-    KUBE_NODE_IP_ADDRESSES+=("${node#*@}")
-  done
-  echo "KUBE_NODE_IP_ADDRESSES: [${KUBE_NODE_IP_ADDRESSES[*]}]" 1>&2
-}
-
 # Verify prereqs on host machine
 function verify-prereqs() {
   local rc

--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -267,7 +267,7 @@ function prepare-node-upgrade() {
 
   # TODO(zmerlynn): Get configure-vm script from ${version}. (Must plumb this
   #                 through all create-node-instance-template implementations).
-  local template_name=$(get-template-name-from-version ${SANITIZED_VERSION})
+  local template_name=$(get-template-name-from-version ${SANITIZED_VERSION} ${NODE_INSTANCE_PREFIX})
   create-node-instance-template "${template_name}"
   # The following is echo'd so that callers can get the template name.
   echo "Instance template name: ${template_name}"
@@ -373,7 +373,7 @@ function do-node-upgrade() {
   # Do the actual upgrade.
   # NOTE(zmerlynn): If you are changing this gcloud command, update
   #                 test/e2e/cluster_upgrade.go to match this EXACTLY.
-  local template_name=$(get-template-name-from-version ${SANITIZED_VERSION})
+  local template_name=$(get-template-name-from-version ${SANITIZED_VERSION} ${NODE_INSTANCE_PREFIX})
   local old_templates=()
   local updates=()
   for group in ${INSTANCE_GROUPS[@]}; do

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -419,8 +419,6 @@ function detect-node-names() {
 
   echo "INSTANCE_GROUPS=${INSTANCE_GROUPS[*]:-}" >&2
   echo "NODE_NAMES=${NODE_NAMES[*]:-}" >&2
-  echo "PJH: INSTANCE_GROUPS=${WINDOWS_INSTANCE_GROUPS[*]:-}" >&2  # REMOVE
-  echo "PJH: NODE_NAMES=${WINDOWS_NODE_NAMES[*]:-}" >&2  # REMOVE
 }
 
 # Detect the IP for the master

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -400,33 +400,6 @@ function detect-node-names() {
   echo "NODE_NAMES=${NODE_NAMES[*]:-}" >&2
 }
 
-# Detect the information about the minions
-#
-# Assumed vars:
-#   ZONE
-# Vars set:
-#   NODE_NAMES
-#   KUBE_NODE_IP_ADDRESSES (array)
-function detect-nodes() {
-  detect-project
-  detect-node-names
-  KUBE_NODE_IP_ADDRESSES=()
-  for (( i=0; i<${#NODE_NAMES[@]}; i++)); do
-    local node_ip=$(gcloud compute instances describe --project "${PROJECT}" --zone "${ZONE}" \
-      "${NODE_NAMES[$i]}" --format='value(networkInterfaces[0].accessConfigs[0].natIP)')
-    if [[ -z "${node_ip-}" ]] ; then
-      echo "Did not find ${NODE_NAMES[$i]}" >&2
-    else
-      echo "Found ${NODE_NAMES[$i]} at ${node_ip}"
-      KUBE_NODE_IP_ADDRESSES+=("${node_ip}")
-    fi
-  done
-  if [[ -z "${KUBE_NODE_IP_ADDRESSES-}" ]]; then
-    echo "Could not detect Kubernetes minion nodes.  Make sure you've launched a cluster with 'kube-up.sh'" >&2
-    exit 1
-  fi
-}
-
 # Detect the IP for the master
 #
 # Assumed vars:

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -113,6 +113,7 @@ if [[ "${ENABLE_CLUSTER_AUTOSCALER}" == "true" ]]; then
 fi
 
 NODE_INSTANCE_PREFIX=${NODE_INSTANCE_PREFIX:-"${INSTANCE_PREFIX}-minion"}
+WINDOWS_NODE_INSTANCE_PREFIX=${WINDOWS_NODE_INSTANCE_PREFIX:-"${INSTANCE_PREFIX}-windows-node"}
 
 NODE_TAGS="${NODE_TAG}"
 
@@ -373,9 +374,12 @@ function upload-tars() {
 #
 # Assumed vars:
 #   NODE_INSTANCE_PREFIX
+#   WINDOWS_NODE_INSTANCE_PREFIX
 # Vars set:
 #   NODE_NAMES
 #   INSTANCE_GROUPS
+#   WINDOWS_NODE_NAMES
+#   WINDOWS_INSTANCE_GROUPS
 function detect-node-names() {
   detect-project
   INSTANCE_GROUPS=()
@@ -383,6 +387,15 @@ function detect-node-names() {
     --project "${PROJECT}" \
     --filter "name ~ '${NODE_INSTANCE_PREFIX}-.+' AND zone:(${ZONE})" \
     --format='value(name)' || true))
+  WINDOWS_INSTANCE_GROUPS=()
+  WINDOWS_INSTANCE_GROUPS+=($(gcloud compute instance-groups managed list \
+    --project "${PROJECT}" \
+    --filter "name ~ '${WINDOWS_NODE_INSTANCE_PREFIX}-.+' AND zone:(${ZONE})" \
+    --format='value(name)' || true))
+
+  # TODO(pjh): search for uses of NODE_NAMES and make sure they use
+  # WINDOWS_NODE_NAMES too if needed!
+  #   (DID EVERY FILE EXCEPT FOR THIS ONE; see TODO in log-dump.sh)
   NODE_NAMES=()
   if [[ -n "${INSTANCE_GROUPS[@]:-}" ]]; then
     for group in "${INSTANCE_GROUPS[@]}"; do
@@ -395,9 +408,19 @@ function detect-node-names() {
   if [[ -n "${HEAPSTER_MACHINE_TYPE:-}" ]]; then
     NODE_NAMES+=("${NODE_INSTANCE_PREFIX}-heapster")
   fi
+  WINDOWS_NODE_NAMES=()
+  if [[ -n "${WINDOWS_INSTANCE_GROUPS[@]:-}" ]]; then
+    for group in "${WINDOWS_INSTANCE_GROUPS[@]}"; do
+      WINDOWS_NODE_NAMES+=($(gcloud compute instance-groups managed \
+        list-instances "${group}" --zone "${ZONE}" --project "${PROJECT}" \
+        --format='value(instance)'))
+    done
+  fi
 
   echo "INSTANCE_GROUPS=${INSTANCE_GROUPS[*]:-}" >&2
   echo "NODE_NAMES=${NODE_NAMES[*]:-}" >&2
+  echo "PJH: INSTANCE_GROUPS=${WINDOWS_INSTANCE_GROUPS[*]:-}" >&2  # REMOVE
+  echo "PJH: NODE_NAMES=${WINDOWS_NODE_NAMES[*]:-}" >&2  # REMOVE
 }
 
 # Detect the IP for the master
@@ -1376,6 +1399,7 @@ function build-windows-kube-env {
   build-linux-kube-env false $file
 
   cat >>$file <<EOF
+WINDOWS_NODE_INSTANCE_PREFIX: $(yaml-quote ${WINDOWS_NODE_INSTANCE_PREFIX})
 NODE_BINARY_TAR_URL: $(yaml-quote ${NODE_BINARY_TAR_URL})
 NODE_BINARY_TAR_HASH: $(yaml-quote ${NODE_BINARY_TAR_HASH})
 K8S_DIR: $(yaml-quote ${WINDOWS_K8S_DIR})
@@ -1825,9 +1849,11 @@ function make-gcloud-network-argument() {
 }
 
 # $1: version (required)
+# $2: Prefix for the template name, i.e. NODE_INSTANCE_PREFIX or
+#     WINDOWS_NODE_INSTANCE_PREFIX.
 function get-template-name-from-version() {
   # trim template name to pass gce name validation
-  echo "${NODE_INSTANCE_PREFIX}-template-${1}" | cut -c 1-63 | sed 's/[\.\+]/-/g;s/-*$//g'
+  echo "${2}-template-${1}" | cut -c 1-63 | sed 's/[\.\+]/-/g;s/-*$//g'
 }
 
 # validates the NODE_LOCAL_SSDS_EXT variable
@@ -2600,9 +2626,8 @@ function create-nodes-template() {
 
   # NOTE: these template names and their format must match
   # create-[linux,windows]-nodes() as well as get-template()!
-  # TODO(pjh): find a better way to manage these (get-template() is annoying).
   local linux_template_name="${NODE_INSTANCE_PREFIX}-template"
-  local windows_template_name="${NODE_INSTANCE_PREFIX}-template-windows"
+  local windows_template_name="${WINDOWS_NODE_INSTANCE_PREFIX}-template"
   create-linux-node-instance-template $linux_template_name
   create-windows-node-instance-template $windows_template_name "${scope_flags[*]}"
 }
@@ -2673,22 +2698,22 @@ function create-linux-nodes() {
 
 # Assumes:
 # - NUM_WINDOWS_MIGS
-# - NODE_INSTANCE_PREFIX
+# - WINDOWS_NODE_INSTANCE_PREFIX
 # - NUM_WINDOWS_NODES
 # - PROJECT
 # - ZONE
 function create-windows-nodes() {
-  local template_name="${NODE_INSTANCE_PREFIX}-template-windows"
+  local template_name="${WINDOWS_NODE_INSTANCE_PREFIX}-template"
 
   local -r nodes="${NUM_WINDOWS_NODES}"
   local instances_left=${nodes}
 
   for ((i=1; i<=${NUM_WINDOWS_MIGS}; i++)); do
-    local group_name="${NODE_INSTANCE_PREFIX}-windows-group-$i"
+    local group_name="${WINDOWS_NODE_INSTANCE_PREFIX}-group-$i"
     if [[ $i == ${NUM_WINDOWS_MIGS} ]]; then
       # TODO: We don't add a suffix for the last group to keep backward compatibility when there's only one MIG.
       # We should change it at some point, but note #18545 when changing this.
-      group_name="${NODE_INSTANCE_PREFIX}-windows-group"
+      group_name="${WINDOWS_NODE_INSTANCE_PREFIX}-group"
     fi
     # Spread the remaining number of nodes evenly
     this_mig_size=$((${instances_left} / (${NUM_WINDOWS_MIGS}-${i}+1)))
@@ -2927,7 +2952,7 @@ function kube-down() {
   local -r batch=200
 
   detect-project
-  detect-node-names # For INSTANCE_GROUPS
+  detect-node-names # For INSTANCE_GROUPS and WINDOWS_INSTANCE_GROUPS
 
   echo "Bringing down cluster"
   set +e  # Do not stop on error
@@ -2938,7 +2963,9 @@ function kube-down() {
     # change during a cluster upgrade.)
     local templates=$(get-template "${PROJECT}")
 
-    for group in ${INSTANCE_GROUPS[@]:-}; do
+    local all_instance_groups=(${INSTANCE_GROUPS[@]} ${WINDOWS_INSTANCE_GROUPS[@]})
+    echo "PJH: all_instance_groups[@]: ${all_instance_groups[@]}"  # REMOVE
+    for group in ${all_instance_groups[@]:-}; do
       if gcloud compute instance-groups managed describe "${group}" --project "${PROJECT}" --zone "${ZONE}" &>/dev/null; then
         gcloud compute instance-groups managed delete \
           --project "${PROJECT}" \
@@ -3060,7 +3087,7 @@ function kube-down() {
     local -a minions
     minions=( $(gcloud compute instances list \
                   --project "${PROJECT}" \
-                  --filter="name ~ '${NODE_INSTANCE_PREFIX}-.+' AND zone:(${ZONE})" \
+                  --filter="(name ~ '${NODE_INSTANCE_PREFIX}-.+' OR name ~ '${WINDOWS_NODE_INSTANCE_PREFIX}-.+') AND zone:(${ZONE})" \
                   --format='value(name)') )
     # If any minions are running, delete them in batches.
     while (( "${#minions[@]}" > 0 )); do
@@ -3215,15 +3242,19 @@ function set-replica-name() {
   REPLICA_NAME="${MASTER_NAME}-${suffix}"
 }
 
-# Gets the instance template for given NODE_INSTANCE_PREFIX. It echos the template name so that the function
-# output can be used.
+# Gets the instance templates in use by the cluster. It echos the template names
+# so that the function output can be used.
 # Assumed vars:
 #   NODE_INSTANCE_PREFIX
+#   WINDOWS_NODE_INSTANCE_PREFIX
 #
 # $1: project
 function get-template() {
+  local linux_filter="${NODE_INSTANCE_PREFIX}-template(-(${KUBE_RELEASE_VERSION_DASHED_REGEX}|${KUBE_CI_VERSION_DASHED_REGEX}))?"
+  local windows_filter="${WINDOWS_NODE_INSTANCE_PREFIX}-template(-(${KUBE_RELEASE_VERSION_DASHED_REGEX}|${KUBE_CI_VERSION_DASHED_REGEX}))?"
+
   gcloud compute instance-templates list \
-    --filter="name ~ '${NODE_INSTANCE_PREFIX}-template(-(${KUBE_RELEASE_VERSION_DASHED_REGEX}|${KUBE_CI_VERSION_DASHED_REGEX}))?'" \
+    --filter="name ~ '${linux_filter}' OR name ~ '${windows_filter}'" \
     --project="${1}" --format='value(name)'
 }
 
@@ -3232,6 +3263,7 @@ function get-template() {
 # Assumed vars:
 #   MASTER_NAME
 #   NODE_INSTANCE_PREFIX
+#   WINDOWS_NODE_INSTANCE_PREFIX
 #   ZONE
 #   REGION
 # Vars set:
@@ -3247,9 +3279,17 @@ function check-resources() {
     KUBE_RESOURCE_FOUND="Managed instance groups ${INSTANCE_GROUPS[@]}"
     return 1
   fi
+  if [[ -n "${WINDOWS_INSTANCE_GROUPS[@]:-}" ]]; then
+    KUBE_RESOURCE_FOUND="Managed instance groups ${WINDOWS_INSTANCE_GROUPS[@]}"
+    return 1
+  fi
 
   if gcloud compute instance-templates describe --project "${PROJECT}" "${NODE_INSTANCE_PREFIX}-template" &>/dev/null; then
     KUBE_RESOURCE_FOUND="Instance template ${NODE_INSTANCE_PREFIX}-template"
+    return 1
+  fi
+  if gcloud compute instance-templates describe --project "${PROJECT}" "${WINDOWS_NODE_INSTANCE_PREFIX}-template" &>/dev/null; then
+    KUBE_RESOURCE_FOUND="Instance template ${WINDOWS_NODE_INSTANCE_PREFIX}-template"
     return 1
   fi
 
@@ -3267,10 +3307,10 @@ function check-resources() {
   local -a minions
   minions=( $(gcloud compute instances list \
                 --project "${PROJECT}" \
-                --filter="name ~ '${NODE_INSTANCE_PREFIX}-.+' AND zone:(${ZONE})" \
+                --filter="(name ~ '${NODE_INSTANCE_PREFIX}-.+' OR name ~ '${WINDOWS_NODE_INSTANCE_PREFIX}-.+') AND zone:(${ZONE})" \
                 --format='value(name)') )
   if (( "${#minions[@]}" > 0 )); then
-    KUBE_RESOURCE_FOUND="${#minions[@]} matching matching ${NODE_INSTANCE_PREFIX}-.+"
+    KUBE_RESOURCE_FOUND="${#minions[@]} matching ${NODE_INSTANCE_PREFIX}-.+ or ${WINDOWS_NODE_INSTANCE_PREFIX}-.+"
     return 1
   fi
 

--- a/cluster/log-dump/log-dump.sh
+++ b/cluster/log-dump/log-dump.sh
@@ -52,6 +52,7 @@ readonly initd_logfiles="docker/log"
 readonly supervisord_logfiles="kubelet.log supervisor/supervisord.log supervisor/kubelet-stdout.log supervisor/kubelet-stderr.log supervisor/docker-stdout.log supervisor/docker-stderr.log"
 readonly systemd_services="kubelet kubelet-monitor kube-container-runtime-monitor ${LOG_DUMP_SYSTEMD_SERVICES:-docker}"
 readonly dump_systemd_journal="${LOG_DUMP_SYSTEMD_JOURNAL:-false}"
+readonly windows_node_logfiles="kubelet.log kube-proxy.log docker.log"
 
 # Limit the number of concurrent node connections so that we don't run out of
 # file descriptors for large clusters.
@@ -195,6 +196,50 @@ function save-logs() {
     copy-logs-from-node "${node_name}" "${dir}" "${files}"
 }
 
+# Saves a copy of the Windows Docker event log to ${WINDOWS_LOGS_DIR}\docker.log
+# on node $1.
+function export-windows-docker-event-log() {
+    local -r node="${1}"
+
+    local -r powershell_cmd="powershell.exe -Command \$log=\$(Get-EventLog -LogName Application -Source Docker); Set-Content '${WINDOWS_LOGS_DIR}\\docker.log' \$log.Message"
+
+    gcloud compute ssh --project "${PROJECT}" --zone "${ZONE}" "${node}" \
+      --command "$powershell_cmd"
+}
+
+# Save log files and serial console output from Windows node $1 into local
+# directory $2.
+# This function shouldn't ever trigger errexit.
+function save-logs-windows() {
+    local -r node="${1}"
+    local -r dest_dir="${2}"
+
+    if [[ ! "${gcloud_supported_providers}" =~ "${KUBERNETES_PROVIDER}" ]]; then
+      echo "Not saving logs for ${node}, Windows log dumping requires gcloud support"
+      return
+    fi
+
+    export-windows-docker-event-log "${node}"
+
+    # TODO(pjh, yujuhong): handle rotated logs and copying multiple files at the
+    # same time.
+    for file in ${windows_node_logfiles[@]}; do
+      remote_file="${WINDOWS_LOGS_DIR}\\${file}"
+      # Retry up to 3 times to allow ssh keys to be properly propagated and
+      # stored.
+      # TODO: only retry when needed!
+      for retry in {1..3}; do
+        gcloud compute scp --recurse --project "${PROJECT}" --zone "${ZONE}" \
+          "${node}:${remote_file}" "${dest_dir}" > /dev/null || true
+        sleep 10
+      done
+    done
+
+    # Serial port 1 contains the Windows console output.
+    gcloud compute instances get-serial-port-output --project "${PROJECT}" \
+      --zone "${ZONE}" --port 1 "${node}" > "${dest_dir}/serial-1.log" || true
+}
+
 # Execute a command in container $2 on node $1.
 # Uses docker because the container may not ordinarily permit direct execution.
 function run-in-docker-container() {
@@ -247,8 +292,13 @@ function dump_masters() {
   fi
 }
 
+# Dumps logs from nodes in the cluster. Linux nodes to dump logs from can be
+# specified via $1 or $use_custom_instance_list. If not specified then the nodes
+# to dump logs for will be detected using detect-node-names(); if Windows nodes
+# are present then they will be detected and their logs will be dumped too.
 function dump_nodes() {
   local node_names=()
+  local windows_node_names=()
   if [[ -n "${1:-}" ]]; then
     echo "Dumping logs for nodes provided as args to dump_nodes() function"
     node_names=( "$@" )
@@ -264,9 +314,12 @@ function dump_nodes() {
     if [[ -n "${NODE_NAMES:-}" ]]; then
       node_names=( "${NODE_NAMES[@]}" )
     fi
+    if [[ -n "${WINDOWS_NODE_NAMES:-}" ]]; then
+      windows_node_names=( "${WINDOWS_NODE_NAMES[@]}" )
+    fi
   fi
 
-  if [[ "${#node_names[@]}" == 0 ]]; then
+  if [[ "${#node_names[@]}" == 0 && "${#windows_node_names[@]}" == 0 ]]; then
     echo "No nodes found!"
     return
   fi
@@ -276,24 +329,31 @@ function dump_nodes() {
     node_logfiles_all="${node_logfiles_all} ${hollow_node_logfiles}"
   fi
 
-  nodes_selected_for_logs=()
+  linux_nodes_selected_for_logs=()
   if [[ -n "${LOGDUMP_ONLY_N_RANDOM_NODES:-}" ]]; then
     # We randomly choose 'LOGDUMP_ONLY_N_RANDOM_NODES' many nodes for fetching logs.
     for index in `shuf -i 0-$(( ${#node_names[*]} - 1 )) -n ${LOGDUMP_ONLY_N_RANDOM_NODES}`
     do
-      nodes_selected_for_logs+=("${node_names[$index]}")
+      linux_nodes_selected_for_logs+=("${node_names[$index]}")
     done
   else
-    nodes_selected_for_logs=( "${node_names[@]}" )
+    linux_nodes_selected_for_logs=( "${node_names[@]}" )
   fi
+  all_selected_nodes=( "${linux_nodes_selected_for_logs[@]}" )
+  all_selected_nodes+=( "${windows_node_names[@]}" )
 
   proc=${max_dump_processes}
-  for node_name in "${nodes_selected_for_logs[@]}"; do
+  for i in "${!all_selected_nodes[@]}"; do
+    node_name="${all_selected_nodes[$i]}"
     node_dir="${report_dir}/${node_name}"
     mkdir -p "${node_dir}"
-    # Save logs in the background. This speeds up things when there are
-    # many nodes.
-    save-logs "${node_name}" "${node_dir}" "${node_logfiles_all}" "${node_systemd_services}" &
+    if [[ "${i}" -lt "${#linux_nodes_selected_for_logs[@]}" ]]; then
+      # Save logs in the background. This speeds up things when there are
+      # many nodes.
+      save-logs "${node_name}" "${node_dir}" "${node_logfiles_all}" "${node_systemd_services}" &
+    else
+      save-logs-windows "${node_name}" "${node_dir}" &
+    fi
 
     # We don't want to run more than ${max_dump_processes} at a time, so
     # wait once we hit that many nodes. This isn't ideal, since one might
@@ -321,6 +381,7 @@ function find_non_logexported_nodes() {
   succeeded_nodes=$(gsutil ls ${gcs_artifacts_dir}/logexported-nodes-registry) || return 1
   echo "Successfully listed marker files for successful nodes"
   NON_LOGEXPORTED_NODES=()
+  # TODO(pjh): check WINDOWS_NODE_NAMES here?
   for node in "${NODE_NAMES[@]}"; do
     if [[ ! "${succeeded_nodes}" =~ "${node}" ]]; then
       NON_LOGEXPORTED_NODES+=("${node}")
@@ -332,6 +393,7 @@ function dump_nodes_with_logexporter() {
   echo "Detecting nodes in the cluster"
   detect-node-names &> /dev/null
 
+  # TODO(pjh): check WINDOWS_NODE_NAMES here?
   if [[ -z "${NODE_NAMES:-}" ]]; then
     echo "No nodes found!"
     return
@@ -356,6 +418,7 @@ function dump_nodes_with_logexporter() {
   if ! "${KUBECTL}" create -f "${KUBE_ROOT}/cluster/log-dump/logexporter-daemonset.yaml"; then
     echo "Failed to create logexporter daemonset.. falling back to logdump through SSH"
     "${KUBECTL}" delete namespace "${logexporter_namespace}" || true
+    # TODO(pjh): check WINDOWS_NODE_NAMES here?
     dump_nodes "${NODE_NAMES[@]}"
     return
   fi
@@ -409,6 +472,7 @@ function dump_nodes_with_logexporter() {
       if [[ "${retry}" == 10 ]]; then
         echo "Final attempt to list marker files failed.. falling back to logdump through SSH"
         "${KUBECTL}" delete namespace "${logexporter_namespace}" || true
+        # TODO(pjh): check WINDOWS_NODE_NAMES here?
         dump_nodes "${NODE_NAMES[@]}"
         return
       fi
@@ -441,10 +505,16 @@ function detect_node_failures() {
   fi
 
   detect-node-names
-  if [ -z "${INSTANCE_GROUPS:-}" ]; then
+  if [[ "${KUBERNETES_PROVIDER}" -eq "gce" ]]; then
+    local all_instance_groups=(${INSTANCE_GROUPS[@]} ${WINDOWS_INSTANCE_GROUPS[@]})
+  else
+    local all_instance_groups=(${INSTANCE_GROUPS[@]})
+  fi
+
+  if [ -z "${all_instance_groups:-}" ]; then
     return
   fi
-  for group in "${INSTANCE_GROUPS[@]}"; do
+  for group in "${all_instance_groups[@]}"; do
     local creation_timestamp=$(gcloud compute instance-groups managed describe \
                               "${group}" \
                               --project "${PROJECT}" \

--- a/cluster/skeleton/util.sh
+++ b/cluster/skeleton/util.sh
@@ -28,11 +28,6 @@ function detect-node-names {
 	echo "NODE_NAMES: [${NODE_NAMES[*]}]" 1>&2
 }
 
-# Get node IP addresses and store in KUBE_NODE_IP_ADDRESSES[]
-function detect-nodes {
-	echo "KUBE_NODE_IP_ADDRESSES: [${KUBE_NODE_IP_ADDRESSES[*]}]" 1>&2
-}
-
 # Verify prereqs on host machine
 function verify-prereqs {
 	echo "Skeleton Provider: verify-prereqs not implemented" 1>&2

--- a/cluster/validate-cluster.sh
+++ b/cluster/validate-cluster.sh
@@ -56,7 +56,7 @@ if [[ "${KUBERNETES_PROVIDER:-}" == "gce" ]]; then
   # In multizone mode we need to add instances for all nodes in the region.
   if [[ "${MULTIZONE:-}" == "true" ]]; then
     EXPECTED_NUM_NODES=$(gcloud -q compute instances list --project="${PROJECT}" --format=[no-heading] \
-      --filter="name ~ '${NODE_INSTANCE_PREFIX}.*' AND zone:($(gcloud -q compute zones list --project="${PROJECT}" --filter=region=${REGION} --format=csv[no-heading]\(name\) | tr "\n" "," | sed  "s/,$//"))" | wc -l)
+      --filter="(name ~ '${NODE_INSTANCE_PREFIX}.*' OR name ~ '${WINDOWS_NODE_INSTANCE_PREFIX}.*') AND zone:($(gcloud -q compute zones list --project="${PROJECT}" --filter=region=${REGION} --format=csv[no-heading]\(name\) | tr "\n" "," | sed  "s/,$//"))" | wc -l)
     echo "Computing number of nodes, NODE_INSTANCE_PREFIX=${NODE_INSTANCE_PREFIX}, REGION=${REGION}, EXPECTED_NUM_NODES=${EXPECTED_NUM_NODES}"
   fi
 else

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -100,6 +100,8 @@ fi
 # set before we get here, which eliminates any cluster/gke use if
 # KUBERNETES_CONFORMANCE_PROVIDER is set to "gke".
 if [[ -z "${NODE_INSTANCE_GROUP:-}" ]] && [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
+  # TODO(pjh): this code is broken, detect-node-instance-groups appears nowhere
+  # else in k/k.
   detect-node-instance-groups
   NODE_INSTANCE_GROUP=$(kube::util::join , "${NODE_INSTANCE_GROUPS[@]}")
 fi


### PR DESCRIPTION
Updates log-dump.sh for Windows nodes.

Tested:
```
$ PROJECT=${CLOUDSDK_CORE_PROJECT} KUBERNETES_SKIP_CONFIRM=y NUM_NODES=2 \
  NUM_WINDOWS_NODES=2 KUBE_GCE_ENABLE_IP_ALIASES=true go run \
  ./hack/e2e.go -- --up
$ cluster/log-dump/log-dump.sh
$ ls _artifacts
```