### PR TITLE
Leave firewall enabled for Windows nodes on GCE.

### DIFF
--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -230,11 +230,6 @@ function Set-EnvironmentVars {
 # Configures various settings and prerequisites needed for the rest of the
 # functions in this module and the Kubernetes binaries to operate properly.
 function Set-PrerequisiteOptions {
-  # The Windows firewall interferes with Kubernetes networking; GCE's firewall
-  # should be sufficient.
-  Log-Output "Disabling Windows Firewall"
-  Set-NetFirewallProfile -Profile Domain, Public, Private -Enabled False
-
   # Windows updates cause the node to reboot at arbitrary times.
   Log-Output "Disabling Windows Update service"
   sc.exe config wuauserv start=disabled


### PR DESCRIPTION
This passed cluster/gce/windows/smoke-test.sh once, shipping it to the POC branch.